### PR TITLE
feat(cache): add cache for faster and stale

### DIFF
--- a/nginxTemplates/default.conf.template
+++ b/nginxTemplates/default.conf.template
@@ -1,3 +1,5 @@
+proxy_cache_path /etc/nginx/cache levels=1:2 keys_zone=enacit4r:64M max_size=10G inactive=24h use_temp_path=off;
+
 server {
     listen ${NGINX_PORT};
     server_name ${NGINX_HOST};
@@ -34,6 +36,20 @@ server {
         add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
         return 204;
       }
+
+      proxy_cache enacit4r;
+      proxy_headers_hash_max_size 512;
+      proxy_headers_hash_bucket_size 128; 
+      proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      add_header X-Proxy-Cache $upstream_cache_status;
+
+      proxy_cache_valid 200 10m;
+      proxy_cache_bypass $arg_should_bypass_cache;
+      proxy_cache_methods GET HEAD;
+      proxy_cache_min_uses 1;
+      proxy_cache_lock on;
+
+      proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
 
       proxy_pass             ${S3_ENDPOINT_PROTOCOL}${S3_ENDPOINT_HOSTNAME}/${S3_BUCKET_NAME}$request_uri;
     }


### PR DESCRIPTION
Co-authored-by: Pierre Guilbert <Pierre.Guilbert@epfl.ch>

Add caching to nginx config with cache zone:
- 10GB cache
- 24h cache invalidation
- 2 tree hierarchie levels cache
- 64MB for cache keys

Cache behaviour
- data is valid for 10 minutes (after that, it will be considered stale)
- cache is bypassed if the request contains the query parameter "should_bypass_cache"
- cache is used for GET and HEAD requests
- cache is used if the response is used at least once
- cache is locked when the response is being generated
- cache is used if the response is stale (error, timeout, 500, 502, 503, 504)