### PR TITLE
fix(cors): make the “add_header” function work on with all status code

### DIFF
--- a/nginxTemplates/default.conf.template
+++ b/nginxTemplates/default.conf.template
@@ -22,7 +22,7 @@ server {
       proxy_intercept_errors on;
       add_header             Cache-Control max-age=31536000;
 
-      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Origin' '*' always;
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
       add_header 'Access-Control-Allow-Methods' 'GET';
@@ -31,7 +31,7 @@ server {
         add_header 'Access-Control-Max-Age' 1728000;
         add_header 'Content-Type' 'text/plain charset=UTF-8';
         add_header 'Content-Length' 0;
-        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Credentials' 'true';
         add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
         return 204;


### PR DESCRIPTION
As explained in the nginx docs: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
to make the “add_header” function work on with all status code you have to add to it the “always” parameter.


- example of before/after adding 'always'
<img width="1346" alt="cors-no-more" src="https://user-images.githubusercontent.com/161889/220395771-9d61435e-7dcf-4c49-bdbc-425724186e6d.png">
