### PR TITLE
feat: replace 403 by 404 and custom page error

### DIFF
--- a/nginxTemplates/default.conf.template
+++ b/nginxTemplates/default.conf.template
@@ -4,6 +4,13 @@ server {
     listen ${NGINX_PORT};
     server_name ${NGINX_HOST};
 
+    error_page 403 =404 @not_found;
+    error_page      404 @not_found;
+
+    location @not_found {
+      return 404 "404 - page not found";
+    }
+
     location /  {
       resolver               ${DNS};
       proxy_http_version     1.1;


### PR DESCRIPTION
We think with (@ymarcon ) that's it's better to respond with a 404 when the file is not present.

Currently the s3 server return a 403 (because it was probably configured that way on the epfl side) and so the cdn return a 403.

We'd prefer for our cdn to return a 404 so that the user knows it's not present (cf https://stackoverflow.com/questions/19037664/how-do-i-have-an-s3-bucket-return-404-instead-of-403-for-a-key-that-does-not-e#:~:text=S3%20returns%20a%20403%20instead,that%20object%20doesn't%20exist. for more information)

