### PR TITLE
feat(cors): problem with cors and 404

### DIFF
--- a/nginxTemplates/default.conf.template
+++ b/nginxTemplates/default.conf.template
@@ -8,6 +8,22 @@ server {
     error_page      404 @not_found;
 
     location @not_found {
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Credentials' 'true'  always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range'  always;
+      add_header 'Access-Control-Allow-Methods' 'GET,OPTIONS'  always;
+      add_header 'Content-Type' 'text/plain charset=UTF-8';
+
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain charset=UTF-8';
+        add_header 'Content-Length' 0;
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+        return 204;
+      }
+
       return 404 "404 - page not found";
     }
 


### PR DESCRIPTION
Concerning the 404 (previously 403) We still have a small inconvenient.

- By default we authorize the CORS for every request.. Sadly when having an error_page (403,404 or wathever. We didn't allow the CORS)
This pull request aim to correct/rectify this oversight
<img width="1128" alt="404_pneuma" src="https://github.com/EPFL-ENAC/enacit4r-cdn/assets/161889/9b71384b-7b7b-486e-93f6-8ef5983f1ad1">
