### PR TITLE
fix(docker-compose): set nginx:1.25 and remove compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 ---
-version: '3.8'
 services:
   web:
-    image: nginx
+    image: nginx:1.25
     restart: unless-stopped
     environment:
       - NGINX_HOST=${HOSTNAME}


### PR DESCRIPTION
Needed to specify nginx version and remove compose file version (```WARN[0000] /opt/enacit4r-cdn/docker-compose.yml: `version` is obsolete```) on prod server after an apt upgrade